### PR TITLE
Fix mobile menu color bug

### DIFF
--- a/components/menuBar/menuBar.module.scss
+++ b/components/menuBar/menuBar.module.scss
@@ -16,7 +16,7 @@
 
 .menu_bar {
   height: 100%;
-  background: var(--main-font-color);
+  background: var(--secondary-color);
   right: 0;
   width: 70vw;
   display: flex;


### PR DESCRIPTION
- replaced background property of menu_bar class to correct CSS variable that had been incorrectly changed in previous commit